### PR TITLE
feat: 손쉬운 사용 권한 확인 및 요청 추가

### DIFF
--- a/ClipMate/ClipMate.entitlements
+++ b/ClipMate/ClipMate.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.input-devices</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 </dict>

--- a/ClipMate/Utils/CopyAndPaste.swift
+++ b/ClipMate/Utils/CopyAndPaste.swift
@@ -25,6 +25,13 @@ class CopyAndPasteManager {
     
     private var eventTap: CFMachPort?
     func eventMonitor(copyCompleteHandler: @escaping (() -> Void), pasteComplateHandler: @escaping() -> Void) {
+        // 손쉬운 사용 권한을 확인하고, 없는 경우 사용자에게 요청합니다.
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+        guard AXIsProcessTrustedWithOptions(options) else {
+            print("손쉬운 사용 권한이 없습니다. 시스템 설정 > 개인정보 보호 및 보안 > 손쉬운 사용에서 권한을 추가해주세요.")
+            return
+        }
+        
         let mask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
         let handlers: Handlers = .init(copyHandler: copyCompleteHandler, pasteHandler: pasteComplateHandler)
         let ref = UnsafeMutableRawPointer(Unmanaged.passUnretained(handlers).toOpaque())


### PR DESCRIPTION
1. dmg 설치 시 권한 문제로 Command + c안되는 현상 해결

Isuee:  사용자가 직접 손쉬운 사용 권한을  줘야 함 

update: 권한이 없는지 확인하는 코드와 손쉬운 사용 권한 허용을 Alert를 만들어야 함.