### PR TITLE
fix: 검색 필드 포커스 해제 및 붙여넣기 후 검색 텍스트 초기화

### DIFF
--- a/ClipMate/ContentView.swift
+++ b/ClipMate/ContentView.swift
@@ -41,6 +41,7 @@ struct ContentView: View {
             }
             .contentShape(Rectangle()) // 빈 영역도 터치 가능
             .onTapGesture {
+                isSearchFocused = false
                 guard vm.editId != nil else { return }
                 vm.editId = nil
             }
@@ -83,9 +84,6 @@ struct ContentView: View {
             Image(systemName: "magnifyingglass")
             TextField("", text: $vm.searchText)
                 .focused($isSearchFocused)
-                .onSubmit {
-                    vm.searchText = ""
-                }
         }
     }
     

--- a/ClipMate/ViewModel/ContentView+ViewModel.swift
+++ b/ClipMate/ViewModel/ContentView+ViewModel.swift
@@ -43,6 +43,7 @@ extension ContentView {
                 pasteComplateHandler: { // Paste Logic
                     if !self.isTextFieldFocused && NSApp.isActive {
                         self.paste()
+                        self.searchText = ""
                     }
                 },
                 completionAuthorization: { authorization in


### PR DESCRIPTION
## Bug Fix : 검색이 활성화 되어있을 때 Enter의 로직이 활성화가 꼬이는 버그

paste가 될 경우 검색의 focus를 Remove

## MVP 끝 ( Copy & Paste )

## 추가 기능 및 SideBar 추가 
> [!IMPORTANT]
>  1. SideBar Design
>  2. ImageCapture And Download
>  3. Image OCR 
>  4. Settings

